### PR TITLE
No longer resubscribe on every render

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function useNetworkStatus() {
     return () => {
       connection.removeEventListener("change", updateConnectionStatus);
     };
-  });
+  }, []);
 
   return connection;
 }


### PR DESCRIPTION
The current `useEffect` will subscribe and unsubscribe on every render. This change makes it so that it only creates the subscription on mount, and removes the subscription on unmount.

[Docs here](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect)

---

Related: https://github.com/rehooks/window-size/pull/1