### PR TITLE
Don't re-create event handler on every render

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,15 +8,16 @@ function getConnection() {
 function useNetworkStatus() {
   let [connection, updateNetworkConnection] = useState(getConnection());
 
-  function updateConnectionStatus() {
-    updateNetworkConnection(getConnection());
-  }
   useEffect(() => {
+    function updateConnectionStatus() {
+      updateNetworkConnection(getConnection());
+    }
+
     connection.addEventListener("change", updateConnectionStatus);
     return () => {
       connection.removeEventListener("change", updateConnectionStatus);
     };
-  }, []);
+  }, [connection]);
 
   return connection;
 }


### PR DESCRIPTION
Since the event handler was defined outside of the effect scope, it is getting wastefully re-created every time the consumer component re-renders, which is unnecessary. We only need a single reference of it for the lifetime of the hook.

The `useEffect` was also missing the `connection` dependency so I added it too.

And as a side note, the current implementation does not trigger a re-render of the consumer component when the connection status changes because the `navigator.connection` object always has the same reference, so calling the state updater with it doesn't do anything. It doesn't seem like this hook is very helpful like that.